### PR TITLE
feat: show messages/queries in sidebar

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -114,16 +114,16 @@ function SideBarItem({ item }: SideBarItemProps) {
                   <AccordionItem value="default" className="border-0 [&_.params]:data-[state=open]:hidden">
                     <AccordionTrigger
                       title={formatName(item.name)}
-                      className="p-2 max-w-full rounded-lg border-b border-border data-[state=closed]:bg-background"
+                      className="p-2 max-w-full rounded-lg border-border data-[state=closed]:border-b data-[state=closed]:bg-background"
                     >
                       <p className="text-sm text-left max-w-[85%] truncate">{formatName(item.name)}</p>
                     </AccordionTrigger>
-                    <div className="params px-2 py-0.5 font-medium text-xs text-muted-foreground">
+                    <div className="params px-2 py-0.5 font-medium text-xs text-muted-foreground truncate">
                       {Object.keys(item.fields).join(', ')}
                     </div>
                     <AccordionContent className="p-2 space-y-2">
                       {Object.keys(item.fields).map((param) => (
-                        <div className="space-y-1">
+                        <div key={param} className="space-y-1">
                           <p className="font-medium space-x-2">
                             <span>{param}</span>
                             <span className="text-muted-foreground font-normal">{item.fields[param]}</span>


### PR DESCRIPTION
Closes: WORLD-853
<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

Display fetched messages & queries in the sidebar.

Screenshot:
![image](https://github.com/Argus-Labs/cardinal-editor/assets/51780559/72187843-8e61-439b-ad00-e212bfd39f86)


## Brief Changelog
- new 'world' query to `/debug/world`

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying
manually tested/verified
<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->