### PR TITLE
feat: add cql back to sidebar

### DIFF
--- a/src/lib/query-options.tsx
+++ b/src/lib/query-options.tsx
@@ -110,6 +110,26 @@ export const lastMessageQueryOptions = ({
   enabled: isCardinalConnected,
 })
 
+export const lastCQLQueryOptions = ({
+  cardinalUrl,
+  isCardinalConnected,
+  body,
+}: lastQueryOptionsProps) => ({
+  queryKey: ['last-query'],
+  queryFn: async () => {
+    const res = await fetch(`${cardinalUrl}/cql`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${cardinalUrl}/cql`)
+    }
+    return res.json()
+  },
+  enabled: isCardinalConnected,
+})
+
 interface personaQueryOptionsProps {
   cardinalUrl: string
   isCardinalConnected: boolean


### PR DESCRIPTION
Closes: WORLD-967
## Overview
CQL endpoint was changed to `/cql` from `/query/game/cql` in [this pr](https://github.com/Argus-Labs/world-engine/pull/674), so for a while it was gone from the sidebar. This PR just adds it back.

## Brief Changelog
- add cql back to sidebar

## Testing and Verifying
manually tested/verified