### PR TITLE
feat: get namespace from /world instead of env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-CARDINAL_NAMESPACE=world-1

--- a/src/lib/cardinal-provider.tsx
+++ b/src/lib/cardinal-provider.tsx
@@ -4,7 +4,6 @@ interface CardinalProviderState {
   cardinalUrl: string
   setCardinalUrl: (url: string) => void
   isCardinalConnected: boolean
-  cardinalNamespace: string
 }
 
 interface CardinalProviderProps {
@@ -14,12 +13,10 @@ interface CardinalProviderProps {
 // TODO: consider whether to put cardinal url/port in .env too
 const storageKey = 'cardinal-url'
 const defaultCardinalUrl = 'http://localhost:4040'
-const defaultCardinalNamespace = (import.meta.env.CARDINAL_NAMESPACE as string) || 'world-1'
 const initialState: CardinalProviderState = {
   cardinalUrl: defaultCardinalUrl,
   setCardinalUrl: () => null,
   isCardinalConnected: false,
-  cardinalNamespace: defaultCardinalNamespace,
 }
 
 const CardinalProviderContext = createContext(initialState)
@@ -55,7 +52,6 @@ export function CardinalProvider({ children, ...props }: CardinalProviderProps) 
       setCardinalUrl(url)
     },
     isCardinalConnected,
-    cardinalNamespace: defaultCardinalNamespace,
   }
 
   return (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface WorldResponse {
   components: WorldField[]
   messages: WorldField[]
   queries: WorldField[]
+  namespace: string
 }
 
 export interface Persona {


### PR DESCRIPTION
Closes: WORLD-968

## Overview
We now get the cardinal namespace from `/world`.

## Brief Changelog
- get namespace from `/world`
- remove .env

## Testing and Verifying
manually tested/verified