### PR TITLE
refactor: fetch queries/messages using urls from /world instead of names

### DIFF
--- a/src/components/sidebar/messages.tsx
+++ b/src/components/sidebar/messages.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/components/ui/select'
 import { accountFromPersona } from '@/lib/account'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { lastMessageQueryOptions, worldQueryOptions } from '@/lib/query-options'
+import { gameQueryOptions, worldQueryOptions } from '@/lib/query-options'
 import { WorldField } from '@/lib/types'
 
 import { formatName } from './utils'
@@ -93,10 +93,10 @@ function Message({ message }: MessageProp) {
       body: fields,
     }
     await queryClient.fetchQuery(
-      lastMessageQueryOptions({
+      gameQueryOptions({
         cardinalUrl,
         isCardinalConnected,
-        name: message.name,
+        url: message.url,
         body,
       }),
     )

--- a/src/components/sidebar/queries.tsx
+++ b/src/components/sidebar/queries.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { lastCQLQueryOptions, lastQueryQueryOptions } from '@/lib/query-options'
+import { gameQueryOptions } from '@/lib/query-options'
 import { WorldField } from '@/lib/types'
 
 import { formatName } from './utils'
@@ -34,7 +34,7 @@ export function SidebarQueries({ queries }: SidebarQueriesProps) {
     fields: {
       CQL: 'string',
     },
-    url: '/cql'
+    url: '/cql',
   }
 
   return (
@@ -56,7 +56,7 @@ export function SidebarQueries({ queries }: SidebarQueriesProps) {
             </div>
           ) : (
             <Accordion collapsible type="single" className="space-y-2">
-              <Query query={cql} isCQL={true} />
+              <Query query={cql} />
               {queries.map((q, i) => (
                 <Query key={i} query={q} />
               ))}
@@ -68,14 +68,11 @@ export function SidebarQueries({ queries }: SidebarQueriesProps) {
   )
 }
 
-// the isCQL boolean field is probably a bad component design, but it works.
-// consider refactoring this later to be cleaner
 interface QueryProp {
   query: WorldField
-  isCQL?: boolean
 }
 
-function Query({ query, isCQL }: QueryProp) {
+function Query({ query }: QueryProp) {
   const { cardinalUrl, isCardinalConnected } = useCardinal()
   const queryClient = useQueryClient()
   // TODO: fix uncontrolled component error by adding default values here, tho we need to set the
@@ -84,17 +81,15 @@ function Query({ query, isCQL }: QueryProp) {
 
   // @ts-ignore
   const handleSubmit = (values) => {
-    const queryOptionProps = {
-      cardinalUrl,
-      isCardinalConnected,
-      name: query.name,
-      body: values as object,
-    }
-    const queryOptions = isCQL
-      ? lastCQLQueryOptions(queryOptionProps)
-      : lastQueryQueryOptions(queryOptionProps)
     queryClient
-      .fetchQuery(queryOptions)
+      .fetchQuery(
+        gameQueryOptions({
+          cardinalUrl,
+          isCardinalConnected,
+          url: query.url,
+          body: values as object,
+        }),
+      )
       .then(() => true)
       .catch((e) => console.log(e))
   }

--- a/src/lib/query-options.ts
+++ b/src/lib/query-options.ts
@@ -61,69 +61,28 @@ export const worldQueryOptions = ({
   enabled: isCardinalConnected,
 })
 
-interface lastQueryOptionsProps {
+interface gameQueryOptionsProps {
   cardinalUrl: string
   isCardinalConnected: boolean
-  name: string // endpoint name
+  url: string
   body: object
 }
 
-export const lastQueryQueryOptions = ({
+export const gameQueryOptions = ({
   cardinalUrl,
   isCardinalConnected,
-  name,
+  url,
   body,
-}: lastQueryOptionsProps) => ({
-  queryKey: ['last-query'],
+}: gameQueryOptionsProps) => ({
+  queryKey: ['game'],
   queryFn: async () => {
-    const res = await fetch(`${cardinalUrl}/query/game/${name}`, {
+    const res = await fetch(`${cardinalUrl}${url}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     })
     if (!res.ok) {
-      throw new Error(`Failed to fetch ${cardinalUrl}/query/game/${name}`)
-    }
-    return res.json()
-  },
-  enabled: isCardinalConnected,
-})
-
-export const lastMessageQueryOptions = ({
-  cardinalUrl,
-  isCardinalConnected,
-  name,
-  body,
-}: lastQueryOptionsProps) => ({
-  queryKey: ['last-query'],
-  queryFn: async () => {
-    const res = await fetch(`${cardinalUrl}/tx/game/${name}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${cardinalUrl}/tx/game/${name}`)
-    }
-    return res.json()
-  },
-  enabled: isCardinalConnected,
-})
-
-export const lastCQLQueryOptions = ({
-  cardinalUrl,
-  isCardinalConnected,
-  body,
-}: lastQueryOptionsProps) => ({
-  queryKey: ['last-query'],
-  queryFn: async () => {
-    const res = await fetch(`${cardinalUrl}/cql`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
-      throw new Error(`Failed to fetch ${cardinalUrl}/cql`)
+      throw new Error(`Failed to fetch ${cardinalUrl}${url}`)
     }
     return res.json()
   },


### PR DESCRIPTION
Closes: WORLD-979

## Overview
Small refactor to use the endpoint urls from `/world` instead of the names.


## Testing and Verifying
manually tested/verified