### PR TITLE
feat: use receipts for error handling

### DIFF
--- a/src/components/sidebar/messages.tsx
+++ b/src/components/sidebar/messages.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/components/ui/select'
 import { accountFromPersona } from '@/lib/account'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { gameQueryOptions, worldQueryOptions } from '@/lib/query-options'
+import { gameMessageQueryOptions, worldQueryOptions } from '@/lib/query-options'
 import { WorldField } from '@/lib/types'
 
 import { formatName } from './utils'
@@ -93,13 +93,14 @@ function Message({ message }: MessageProp) {
       body: fields,
     }
     await queryClient.fetchQuery(
-      gameQueryOptions({
+      gameMessageQueryOptions({
         cardinalUrl,
         isCardinalConnected,
         url: message.url,
         body,
       }),
     )
+    // increment nonce for the persona that submitted the message
     setPersonas(
       personas.map((p) => {
         return p.personaTag === personaTag ? { ...p, nonce: p.nonce + 1 } : p

--- a/src/components/sidebar/persona.tsx
+++ b/src/components/sidebar/persona.tsx
@@ -16,9 +16,9 @@ import { Input } from '@/components/ui/input'
 import { createPersonaAccount } from '@/lib/account'
 import { useCardinal } from '@/lib/cardinal-provider'
 import { personaQueryOptions, receiptsQueryOptions, worldQueryOptions } from '@/lib/query-options'
+import { sleep } from '@/lib/utils'
 
 import { useToast } from '../ui/use-toast'
-import { sleep } from '@/lib/utils'
 
 const formSchema = z.object({
   personaTag: z
@@ -68,15 +68,17 @@ export function CreatePersona() {
     await sleep(1000)
 
     const receiptBody = { startTick: res.Tick }
-    const receipt = await queryClient.fetchQuery(receiptsQueryOptions({ cardinalUrl, isCardinalConnected, body: receiptBody }))
+    const receipt = await queryClient.fetchQuery(
+      receiptsQueryOptions({ cardinalUrl, isCardinalConnected, body: receiptBody }),
+    )
 
     // TODO: verify this
     // we could just retry the query, however I couldn't get the receipt again after fetching
     // a null receipt. this might me a bug with cardinal, or a feature(?).
     if (!receipt.receipts) {
       toast({
-        title: 'Couldn\'t fetch receipt',
-        description: 'We couldn\'t verify whether the persona was successfully created or not',
+        title: "Couldn't fetch receipt",
+        description: "We couldn't verify whether the persona was successfully created or not",
       })
       return
     }

--- a/src/components/sidebar/persona.tsx
+++ b/src/components/sidebar/persona.tsx
@@ -83,12 +83,12 @@ export function CreatePersona() {
           toast({
             title: `Successfully created persona ${personaTag}`,
           })
+          // only set the personas if there is no error
+          const newPersona = { personaTag, privateKey, address, nonce: nonce + 1 }
+          setPersonas([...personas, newPersona])
         })
         .catch((e) => console.log(e))
     }, 1000)
-
-    const newPersona = { personaTag, privateKey, address, nonce: nonce + 1 }
-    setPersonas([...personas, newPersona])
   }
 
   return (

--- a/src/components/sidebar/queries.tsx
+++ b/src/components/sidebar/queries.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { gameQueryOptions } from '@/lib/query-options'
+import { gameQueryQueryOptions } from '@/lib/query-options'
 import { WorldField } from '@/lib/types'
 
 import { formatName } from './utils'
@@ -83,7 +83,7 @@ function Query({ query }: QueryProp) {
   const handleSubmit = (values) => {
     queryClient
       .fetchQuery(
-        gameQueryOptions({
+        gameQueryQueryOptions({
           cardinalUrl,
           isCardinalConnected,
           url: query.url,

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -13,7 +13,7 @@ export function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+      {toasts.map(function({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>
             <div className="grid gap-1">
@@ -25,7 +25,7 @@ export function Toaster() {
           </Toast>
         )
       })}
-      <ToastViewport />
+      <ToastViewport className="absolute" />
     </ToastProvider>
   )
 }

--- a/src/lib/query-options.ts
+++ b/src/lib/query-options.ts
@@ -1,10 +1,11 @@
-import { Entity, WorldResponse } from '@/lib/types'
+import { Entity, Receipt, TransactionReturn, WorldResponse } from '@/lib/types'
 
 // TODO: consider returning error status & message instead of throwing
 
 interface cardinalQueryOptionsProps {
   cardinalUrl: string
   isCardinalConnected: boolean
+  body?: object
 }
 
 export const stateQueryOptions = ({
@@ -89,17 +90,11 @@ export const gameQueryOptions = ({
   enabled: isCardinalConnected,
 })
 
-interface personaQueryOptionsProps {
-  cardinalUrl: string
-  isCardinalConnected: boolean
-  body: object
-}
-
 export const personaQueryOptions = ({
   cardinalUrl,
   isCardinalConnected,
   body,
-}: personaQueryOptionsProps) => ({
+}: cardinalQueryOptionsProps) => ({
   queryKey: ['persona'],
   queryFn: async () => {
     const res = await fetch(`${cardinalUrl}/tx/persona/create-persona`, {
@@ -110,7 +105,27 @@ export const personaQueryOptions = ({
     if (!res.ok) {
       throw new Error(`Failed to fetch ${cardinalUrl}/tx/persona/create-persona`)
     }
-    return res.json()
+    return res.json() as Promise<TransactionReturn>
+  },
+  enabled: isCardinalConnected,
+})
+
+export const receiptsQueryOptions = ({
+  cardinalUrl,
+  isCardinalConnected,
+  body,
+}: cardinalQueryOptionsProps) => ({
+  queryKey: ['receipts'],
+  queryFn: async () => {
+    const res = await fetch(`${cardinalUrl}/query/receipts/list`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${cardinalUrl}/query/receipts/list`)
+    }
+    return res.json() as Promise<Receipt>
   },
   enabled: isCardinalConnected,
 })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,3 +30,23 @@ export interface Persona {
   address: string
   nonce: number
 }
+
+export interface TransactionReturn {
+  TxHash: string
+  Tick: number
+}
+
+export interface Receipt {
+  startTick: number
+  endTick: number
+  receipts:
+    | {
+        txHash: string
+        tick: number
+        result: {
+          success: boolean
+        } | null
+        errors: string[] | null
+      }[]
+    | null
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,5 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const sleep = async (duration: number) => await new Promise(r => setTimeout(r, duration))

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,4 +5,4 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const sleep = async (duration: number) => await new Promise(r => setTimeout(r, duration))
+export const sleep = async (duration: number) => await new Promise((r) => setTimeout(r, duration))

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -42,17 +42,17 @@ function Root() {
         <Sidebar />
         <div className="w-full">
           <ResizablePanelGroup direction="vertical">
-            <ResizablePanel>
+            <ResizablePanel className="relative">
               <div className="bg-muted h-full px-4 pt-4 pb-16 overflow-y-auto">
                 <Outlet />
               </div>
+              <Toaster />
             </ResizablePanel>
             <ResizableHandle withHandle />
             <BottomBar />
           </ResizablePanelGroup>
         </div>
       </main>
-      <Toaster />
     </>
   )
 }


### PR DESCRIPTION
Closes: WORLD-962

## Overview
Previously messages requests return the transaction hash & tick, and these were shown to the users (bottom bar), or no indicators were shown to the users when the request failed.

Now, create persona requests display the transaction receipt results in a toast, and the receipt results are shown after submitting messages.

## Brief Changelog
- error handling by reading receipts for create persona
- only add new persona to config if no error happened
- return receipt instead of txhash when submitting messages

## Testing and Verifying
manually tested/verified