### PR TITLE
feat: setup ws connection to receive & show events in toasts

### DIFF
--- a/src/lib/query-options.ts
+++ b/src/lib/query-options.ts
@@ -1,13 +1,12 @@
 import { Entity, Receipt, TransactionReturn, WorldResponse } from '@/lib/types'
 import { sleep } from '@/lib/utils'
 
-// TODO: consider returning error status & message instead of throwing
-
 // builtin endpoints
 export const routeDebugState = '/debug/state'
 export const routeHealth = '/health'
 export const routeWorld = '/world'
 export const routeCql = '/cql'
+export const routeEvents = '/events'
 export const routeMsgCreatePersona = '/tx/persona/create-persona'
 export const routeMsgAuthorizePersonaAddress = '/tx/game/authorize-persona-address'
 export const routeQryPersonaSigner = '/query/persona/signer'

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,13 +10,13 @@ import { Toaster } from '@/components/ui/toaster'
 import { useToast } from '@/components/ui/use-toast'
 import { createPersonaAccount } from '@/lib/account'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { errorToast } from '@/lib/utils'
 import {
   personaQueryOptions,
   routeEvents,
   syncStateQueryOptions,
   worldQueryOptions,
 } from '@/lib/query-options'
+import { errorToast } from '@/lib/utils'
 
 export const Route = createRootRoute({
   component: Root,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,12 +10,21 @@ import { Toaster } from '@/components/ui/toaster'
 import { useToast } from '@/components/ui/use-toast'
 import { createPersonaAccount } from '@/lib/account'
 import { useCardinal } from '@/lib/cardinal-provider'
-import { personaQueryOptions, syncStateQueryOptions, worldQueryOptions } from '@/lib/query-options'
 import { errorToast } from '@/lib/utils'
+import {
+  personaQueryOptions,
+  routeEvents,
+  syncStateQueryOptions,
+  worldQueryOptions,
+} from '@/lib/query-options'
 
 export const Route = createRootRoute({
   component: Root,
 })
+
+interface CardinalEvent {
+  Events: string[]
+}
 
 function Root() {
   const { personas, setPersonas, cardinalUrl, isCardinalConnected } = useCardinal()
@@ -82,7 +91,23 @@ function Root() {
       }
     }
     if (isCardinalConnected) sync().catch((e) => console.log(e))
-  }, [isCardinalConnected])
+  }, [isCardinalConnected, cardinalUrl, toast])
+
+  // setup websocket connection to receive events
+  useEffect(() => {
+    const wsCardinalUrl = cardinalUrl.replace(/https|http/, 'ws')
+    const ws = new WebSocket(`${wsCardinalUrl}${routeEvents}`)
+    ws.onopen = () => console.log('Connected to events ws')
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data as string) as CardinalEvent
+      if (data.Events && data.Events.length > 0) {
+        // data.Events is an array of base64-ed JSON representation of an event
+        const event = JSON.parse(atob(data.Events[0])) as { [key: string]: string }
+        toast({ title: event.event })
+      }
+    }
+    return () => ws.close()
+  }, [isCardinalConnected, cardinalUrl, toast])
 
   return (
     <>


### PR DESCRIPTION
closes: WORLD-1072

# Overview
Cardinal editor now shows in game events (emitted using world.EmitEvent) to users in toasts. A websocket connection is established when the app starts.

Screencasts:

[Screencast from 2024-04-23 23-42-56.webm](https://github.com/Argus-Labs/cardinal-editor/assets/51780559/bfdcb778-e989-49c9-9ab2-69e63245b6cd)

# Brief Changelog
- setup ws connection to receive & show events in toasts

# Testing and Verifying
Manually verified
