### PR TITLE
feat: nonce-less transactions for use with cardinal v1.7.0+

### DIFF
--- a/src/lib/query-options.ts
+++ b/src/lib/query-options.ts
@@ -117,13 +117,13 @@ interface Receipt {
   startTick: number
   endTick: number
   receipts:
-  | {
-    txHash: string
-    tick: number
-    result: object | null
-    errors: string[] | null
-  }[]
-  | null
+    | {
+        txHash: string
+        tick: number
+        result: object | null
+        errors: string[] | null
+      }[]
+    | null
 }
 
 export const gameMessageQueryOptions = ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,5 +28,4 @@ export interface Persona {
   personaTag: string
   privateKey: string
   address: string
-  nonce: number
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -11,11 +11,11 @@
 // Import Routes
 
 import { Route as rootRoute } from './routes/__root'
-import { Route as CardinalImport } from './routes/_cardinal'
-import { Route as CardinalCardinalImport } from './routes/_cardinal.cardinal'
 import { Route as JaegerImport } from './routes/_jaeger'
-import { Route as JaegerJaegerImport } from './routes/_jaeger.jaeger'
+import { Route as CardinalImport } from './routes/_cardinal'
 import { Route as IndexImport } from './routes/index'
+import { Route as JaegerJaegerImport } from './routes/_jaeger.jaeger'
+import { Route as CardinalCardinalImport } from './routes/_cardinal.cardinal'
 
 // Create/Update Routes
 


### PR DESCRIPTION
Closes: WORLD-1227

# Overview

This PR updates the editor's transaction handling to support Cardinal v1.7.0+ nonce-less transactions. Here's a [doc explaining the implementation details](https://www.notion.so/arguslabs/Nakama-relay-nonce-elimination-119c63b376aa8093bea5debfce76f59e?pvs=4).

To test locally, update the project's `go.mod` file to use Cardinal v1.7.0-beta. If you're using the starter game template, you'll also need to refactor all imports of `"pkg.world.dev/world-engine/cardinal/search/filter"` -> `"pkg.world.dev/world-engine/cardinal/filter"`.

**TODO**:
- [ ] update `version_map.json`

# Brief Changelog

- Change the format of the transaction payload to sign
- Add a `createTransaction` function for accounts to abstract away the signing details

# Testing and Verifying

Manually tested and verified



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced persona management and transaction creation processes for improved user experience.
	- Streamlined message submission logic, simplifying how messages are sent.
  
- **Bug Fixes**
	- Improved error handling for persona creation and message sending, ensuring users receive appropriate feedback.

- **Documentation**
	- Updated comments and explanations for clarity on persona synchronization and transaction processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->